### PR TITLE
PDP-1182 SECCMP-1797: Add top-level permissions to restrict default token

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,17 +1,17 @@
 name: PR Workflow
 
 on:
-  # Using pull_request_target instead of pull_request to handle PRs from forks
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
 
 jobs:
   jira-pr-check:
     name: 🏷️ Validate JIRA ticket ID
-    # Use the reusable workflow from the central repository
     uses: marklogic/pr-workflows/.github/workflows/jira-id-check.yml@main
     with:
-      # Pass the PR title from the event context
       pr-title: ${{ github.event.pull_request.title }}
   copyright-validation:
     name: © Validate Copyright Headers

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![GitHub release](https://img.shields.io/github/release/marklogic-community/marklogic-unit-test.svg)
-![GitHub last commit](https://img.shields.io/github/last-commit/marklogic-community/marklogic-unit-test.svg)
+![GitHub release](https://img.shields.io/github/release/marklogic/marklogic-unit-test.svg)
+![GitHub last commit](https://img.shields.io/github/last-commit/marklogic/marklogic-unit-test.svg)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # Easy testing of custom MarkLogic modules
@@ -19,5 +19,5 @@ marklogic-unit-test includes the following components:
    popular Java testing frameworks. As of the 2.0.0 release, these now require Java 17 or higher. 
 4. A REST endpoint for integrating with testing frameworks in any language.
 
-Please see [the user guide](https://marklogic-community.github.io/marklogic-unit-test/) to get started with adding
+Please see [the user guide](https://marklogic.github.io/marklogic-unit-test/) to get started with adding
 marklogic-unit-test to your project.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,8 +9,8 @@ logo: "/assets/ProgressMarkLogic_PrimaryLogo_Stacked.svg"
 
 # Aux links for the upper right navigation
 aux_links:
-  "marklogic-community/marklogic-unit-test":
-    - "https://github.com/marklogic-community/marklogic-unit-test"
+  "marklogic/marklogic-unit-test":
+    - "https://github.com/marklogic/marklogic-unit-test"
 
 # Makes Aux links open in a new tab. Default is false
 aux_links_new_tab: false

--- a/docs/assertion-functions.md
+++ b/docs/assertion-functions.md
@@ -5,7 +5,7 @@ nav_order: 7
 ---
 
 The list below captures the assertion functions available in the marklogic-unit-test `/test/test-helper.xqy` module.
-You can also [browse the source code](https://github.com/marklogic-community/marklogic-unit-test/blob/master/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy)
+You can also [browse the source code](https://github.com/marklogic/marklogic-unit-test/blob/master/marklogic-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy)
 for this module to examine these functions.
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ running a simple test.
 
 ## Example project description 
 
-The [example project](https://github.com/marklogic-community/marklogic-unit-test/tree/master/examples/getting-started)
+The [example project](https://github.com/marklogic/marklogic-unit-test/tree/master/examples/getting-started)
 for this guide is a simple MarkLogic application with a
 [custom REST endpoint](https://docs.marklogic.com/guide/rest-dev/extensions) named "thesaurus". The endpoint
 returns thesaurus entries via the `/example/lib.sjs` module located at `src/main/ml-modules/root` in the project.
@@ -66,7 +66,7 @@ The above configuration enables the ml-gradle `mlUnitTest` task to access the `m
 allowing it to run your marklogic-unit-test tests.
 
 If you are not using ml-gradle, you will need to manually add the marklogic-unit-test modules to your project. Please
-see [the marklogic-unit-test releases](https://github.com/marklogic-community/marklogic-unit-test/releases) for 
+see [the marklogic-unit-test releases](https://github.com/marklogic/marklogic-unit-test/releases) for 
 zip files containing these modules. 
 
 ## Writing a test

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,5 +29,5 @@ If you have any questions or run into issues while using marklogic-unit-test, tr
 
 1. Check for a similar question [on Stack Overflow](https://stackoverflow.com/questions/tagged/marklogic).
 2. If you don't find a similar question, [ask one yourself](https://stackoverflow.com/questions/ask?tags=marklogic).
-3. Or [submit an issue](https://github.com/marklogic-community/marklogic-unit-test/issues/new); expect a response 
+3. Or [submit an issue](https://github.com/marklogic/marklogic-unit-test/issues/new); expect a response 
    within a day or two. 

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -50,14 +50,14 @@ tests. Any failed test will display a message capturing the assertion failure.
 
 ## Using JUnit5
 
-The [marklogic-junit5 library](https://github.com/marklogic-community/marklogic-unit-test/tree/master/marklogic-junit5) 
+The [marklogic-junit5 library](https://github.com/marklogic/marklogic-unit-test/tree/master/marklogic-junit5) 
 within this project provides support for testing REST endpoints in MarkLogic. It also supports running your 
 marklogic-unit-test tests as part of a JUnit test suite. This allows for a single test run to execute and report on 
 all of your tests - both your JUnit5 tests that invoke REST endpoints in MarkLogic and each of your marklogic-unit-test
 test modules.
 
 For further information, see 
-[the marklogic-junit5 example project](https://github.com/marklogic-community/marklogic-unit-test/tree/master/marklogic-junit5/examples/simple-ml-gradle)
+[the marklogic-junit5 example project](https://github.com/marklogic/marklogic-unit-test/tree/master/marklogic-junit5/examples/simple-ml-gradle)
 that describes the configuration necessary.
 
 ## Using the marklogic-unit-test REST extension

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -7,7 +7,7 @@ nav_order: 3
 This guide is a reference on the different kinds of test modules, setup modules, and teardown modules you can write 
 and run with marklogic-unit-test. The examples shown in this page can be found
 in the `src/test/ml-modules/root/test/suites/thesaurus` directory in the
-[test-examples project](https://github.com/marklogic-community/marklogic-unit-test/tree/master/examples/test-examples).
+[test-examples project](https://github.com/marklogic/marklogic-unit-test/tree/master/examples/test-examples).
 
 ## Location of test files
 

--- a/marklogic-junit5/README.md
+++ b/marklogic-junit5/README.md
@@ -8,7 +8,7 @@ This library makes that as simple as possible by providing the following support
 configuration you've already defined in your project
 1. Clear your test database before a test run so it always runs in a known state
 1. Easily read and make assertions on JSON and XML documents, including support for XPath-based assertions
-1. Easily integrate [marklogic-unit-test](https://github.com/marklogic-community/marklogic-unit-test) tests into a JUnit test suite
+1. Easily integrate [marklogic-unit-test](https://github.com/marklogic/marklogic-unit-test) tests into a JUnit test suite
 
 Below is a simple example of a JUnit test that writes a couple documents, runs a search on them, and then reads them 
 back and verifies the contents of each document:
@@ -45,7 +45,7 @@ As of DHF 5.5, support exists within DHF 5 for writing tests and should be used 
 See [this example project](https://github.com/marklogic/marklogic-data-hub/tree/master/examples/reference-entity-model#testing-support) 
 for more information.
 
-If you're using DHF 4, see [the DHF 4 example project](https://github.com/marklogic-community/marklogic-unit-test/tree/1.0.0/marklogic-junit5/examples/simple-dhf4)
+If you're using DHF 4, see [the DHF 4 example project](https://github.com/marklogic/marklogic-unit-test/tree/1.0.0/marklogic-junit5/examples/simple-dhf4)
 from the 1.0.0 tag of this repository. 
 
 ## Running the tests within this project

--- a/marklogic-junit5/build.gradle
+++ b/marklogic-junit5/build.gradle
@@ -44,7 +44,7 @@ publishing {
         name = "${group}:${project.name}"
         description = "Supports testing MarkLogic applications"
         packaging = "jar"
-        url = "https://github.com/marklogic-community/${project.name}"
+        url = "https://github.com/marklogic/${project.name}"
         licenses {
           license {
             name = "The Apache License, Version 2.0"
@@ -61,9 +61,9 @@ publishing {
           }
         }
         scm {
-          url = "git@github.com:marklogic-community/${project.name}.git"
-          connection = "scm:git@github.com:marklogic-community/${project.name}.git"
-          developerConnection = "scm:git@github.com:marklogic-community/${project.name}.git"
+          url = "git@github.com:marklogic/${project.name}.git"
+          connection = "scm:git@github.com:marklogic/${project.name}.git"
+          developerConnection = "scm:git@github.com:marklogic/${project.name}.git"
         }
       }
     }

--- a/marklogic-junit5/examples/simple-ml-gradle/README.md
+++ b/marklogic-junit5/examples/simple-ml-gradle/README.md
@@ -1,6 +1,6 @@
 This project shows a basic setup for writing JUnit tests with marklogic-junit5 against an application deployed 
-with [ml-gradle](https://github.com/marklogic-community/ml-gradle). In addition, it includes an example of executing
-tests written using [marklogic-unit-test](https://github.com/marklogic-community/marklogic-unit-test) via JUnit.
+with [ml-gradle](https://github.com/marklogic/ml-gradle). In addition, it includes an example of executing
+tests written using [marklogic-unit-test](https://github.com/marklogic/marklogic-unit-test) via JUnit.
 
 ## Trying the project out locally
 

--- a/marklogic-junit5/src/main/java/com/marklogic/junit5/dhf/DataHubUnitTestsTest.java
+++ b/marklogic-junit5/src/main/java/com/marklogic/junit5/dhf/DataHubUnitTestsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.junit5.dhf;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 /**
  * This is a JUnit 5 parameterized test that invokes every test module defined by the REST endpoint provided by the
- * marklogic-unit-test framework - https://github.com/marklogic-community/marklogic-unit-test . This class is abstract
+ * marklogic-unit-test framework - https://github.com/marklogic/marklogic-unit-test . This class is abstract
  * so that it is not run when executing tests for the marklogic-junit5 project - it is instead expected to be extended
  * in a project that depends on marklogic-junit5.
  * <p>

--- a/marklogic-junit5/src/main/java/com/marklogic/junit5/spring/MarkLogicUnitTestsTest.java
+++ b/marklogic-junit5/src/main/java/com/marklogic/junit5/spring/MarkLogicUnitTestsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  */
 package com.marklogic.junit5.spring;
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 
 /**
  * This is a JUnit 5 parameterized test that invokes every test module defined by the REST endpoint provided by the
- * marklogic-unit-test framework - https://github.com/marklogic-community/marklogic-unit-test . This class is abstract
+ * marklogic-unit-test framework - https://github.com/marklogic/marklogic-unit-test . This class is abstract
  * so that it is not run when executing tests for the marklogic-junit5 project - it is instead expected to be extended
  * in a project that depends on marklogic-junit5.
  * <p>

--- a/marklogic-unit-test-client/build.gradle
+++ b/marklogic-unit-test-client/build.gradle
@@ -25,7 +25,7 @@ publishing {
         name = "${group}:${project.name}"
         description = "Supports testing MarkLogic applications"
         packaging = "jar"
-        url = "https://github.com/marklogic-community/${project.name}"
+        url = "https://github.com/marklogic/${project.name}"
         licenses {
           license {
             name = "The Apache License, Version 2.0"
@@ -42,9 +42,9 @@ publishing {
           }
         }
         scm {
-          url = "git@github.com:marklogic-community/${project.name}.git"
-          connection = "scm:git@github.com:marklogic-community/${project.name}.git"
-          developerConnection = "scm:git@github.com:marklogic-community/${project.name}.git"
+          url = "git@github.com:marklogic/${project.name}.git"
+          connection = "scm:git@github.com:marklogic/${project.name}.git"
+          developerConnection = "scm:git@github.com:marklogic/${project.name}.git"
         }
       }
     }

--- a/marklogic-unit-test-modules/build.gradle
+++ b/marklogic-unit-test-modules/build.gradle
@@ -35,7 +35,7 @@ publishing {
         name = "${group}:${project.name}"
         description = "Supports testing MarkLogic applications"
         packaging = "jar"
-        url = "https://github.com/marklogic-community/${project.name}"
+        url = "https://github.com/marklogic/${project.name}"
         licenses {
           license {
             name = "The Apache License, Version 2.0"
@@ -52,9 +52,9 @@ publishing {
           }
         }
         scm {
-          url = "git@github.com:marklogic-community/${project.name}.git"
-          connection = "scm:git@github.com:marklogic-community/${project.name}.git"
-          developerConnection = "scm:git@github.com:marklogic-community/${project.name}.git"
+          url = "git@github.com:marklogic/${project.name}.git"
+          connection = "scm:git@github.com:marklogic/${project.name}.git"
+          developerConnection = "scm:git@github.com:marklogic/${project.name}.git"
         }
       }
       artifact sourcesJar


### PR DESCRIPTION
## SECCMP-1797: Add top-level permissions to restrict default token

Adds `permissions: contents: read` at the workflow level to restrict the default GITHUB_TOKEN scope. Without this, all jobs inherit the full `pull_request_target` write token.

The `copyright-validation` job already declares its own `permissions` block which overrides the default for that specific job.

Ref: [Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)